### PR TITLE
fix bug sequence post give wrong content-type

### DIFF
--- a/async_tls_client/response.py
+++ b/async_tls_client/response.py
@@ -3,6 +3,7 @@ from .structures import CaseInsensitiveDict
 
 from typing import Union
 import json
+import base64
 
 
 class Response:
@@ -72,7 +73,7 @@ def build_response(res: Union[dict, list], res_cookies: RequestsCookieJar) -> Re
     # Add cookies
     response.cookies = res_cookies
     # Add response body
-    response.text = res["body"]
+    response.text = base64.b64decode(res["body"].split(',')[1]).decode(errors='ignore')
     # Add response content (bytes)
-    response._content = res["body"].encode()
+    response._content = base64.b64decode(res["body"].split(',')[1])
     return response

--- a/async_tls_client/sessions.py
+++ b/async_tls_client/sessions.py
@@ -427,6 +427,7 @@ class AsyncSession:
                 "headerOrder": self.header_order,
                 "insecureSkipVerify": insecure_skip_verify,
                 "isByteRequest": is_byte_request,
+                "isByteResponse": True,
                 "additionalDecode": self.additional_decode,
                 "proxyUrl": final_proxy,
                 "requestUrl": final_url,


### PR DESCRIPTION
Cherry-picked commits from this PR - https://github.com/FlorianREGAZ/Python-Tls-Client/pull/116
It fixes the issue where the response would be in bytes and the library would just assume it's text